### PR TITLE
Add documents tree fetch snippet

### DIFF
--- a/frontend/components/DocumentsTree.tsx
+++ b/frontend/components/DocumentsTree.tsx
@@ -1,0 +1,24 @@
+// DocumentsTree component snippet from "Codex Task 5". Lists folders and files
+// while excluding '.keep' placeholders so empty folders are shown in the UI.
+
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
+
+export async function listDocuments(basePath: string) {
+  // list docs including prefixes
+  const { data, error } = await supabase.storage
+    .from('original-docs')
+    .list(basePath, {
+      limit: 1000,
+      offset: 0,
+      sortBy: { column: 'name', order: 'asc' }
+    });
+
+  if (error) throw error;
+
+  const folders = data?.prefixes?.filter((p: string) => !p.endsWith('/.keep')) ?? [];
+  const files   = data?.items?.filter((f) => f.name !== '.keep') ?? [];
+
+  return { folders, files };
+}


### PR DESCRIPTION
## Summary
- add a DocumentsTree snippet that lists storage folders and files

## Testing
- `npm test --silent`
- `npm run migrate --silent` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859c5e4a2508330861445939b2aaa42